### PR TITLE
Ast.List<T> performance tweaks

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1039,10 +1039,11 @@ namespace Esprima
 
                     break;
                 case Nodes.ArrayExpression:
-                    var elements = new Ast.List<ArrayPatternElement>();
-
-                    foreach (var element in expr.As<ArrayExpression>().Elements)
+                    var list = expr.As<ArrayExpression>().Elements;
+                    var elements = new Ast.List<ArrayPatternElement>(list.Count);
+                    for (var i = 0; i < list.Count; i++)
                     {
+                        var element = list[i];
                         if (element != null)
                         {
                             elements.Add(ReinterpretExpressionAsPattern(element).As<ArrayPatternElement>());
@@ -1060,13 +1061,15 @@ namespace Esprima
 
                     break;
                 case Nodes.ObjectExpression:
-                    var properties = new Ast.List<Property>();
-
-                    foreach (var property in (expr.As<ObjectExpression>()).Properties)
+                    var props = expr.As<ObjectExpression>().Properties;
+                    var properties = new Ast.List<Property>(props.Count);
+                    for (var i = 0; i < props.Count; i++)
                     {
+                        var property = props[i];
                         property.Value = ReinterpretExpressionAsPattern(property.Value).As<PropertyValue>();
                         properties.Add(property);
                     }
+
                     node = new ObjectPattern(properties);
                     node.Range = expr.Range;
                     node.Location = _config.Loc ? expr.Location : null;
@@ -1148,11 +1151,13 @@ namespace Esprima
                                     Expect("=>");
                                 }
                                 _context.IsBindingElement = false;
-                                var reinterpretedExpressions = new Ast.List<Expression>();
-                                foreach (var expression in expressions)
+                                var reinterpretedExpressions = new Ast.List<Expression>(expressions.Count);
+                                for (var index = 0; index < expressions.Count; index++)
                                 {
+                                    var expression = expressions[index];
                                     reinterpretedExpressions.Add(ReinterpretExpressionAsPattern(expression).As<Expression>());
                                 }
+
                                 expressions = reinterpretedExpressions;
                                 arrow = true;
                                 expr = new ArrowParameterPlaceHolder(expressions.Select(e => (INode) e));
@@ -1192,11 +1197,13 @@ namespace Esprima
                                 if (expr.Type == Nodes.SequenceExpression)
                                 {
                                     var sequenceExpression = expr.As<SequenceExpression>();
-                                    var reinterpretedExpressions = new Ast.List<Expression>();
-                                    foreach (var expression in sequenceExpression.Expressions)
+                                    var reinterpretedExpressions = new Ast.List<Expression>(sequenceExpression.Expressions.Count);
+                                    for (var i = 0; i < sequenceExpression.Expressions.Count; i++)
                                     {
+                                        var expression = sequenceExpression.Expressions[i];
                                         reinterpretedExpressions.Add(ReinterpretExpressionAsPattern(expression).As<Expression>());
                                     }
+
                                     sequenceExpression.Expressions = reinterpretedExpressions;
                                 }
                                 else
@@ -1737,22 +1744,28 @@ namespace Esprima
                     CheckPatternParam(options, param.As<AssignmentPattern>().Left);
                     break;
                 case Nodes.ArrayPattern:
-                    foreach (var element in param.As<ArrayPattern>().Elements)
+                    var list = param.As<ArrayPattern>().Elements;
+                    for (var i = 0; i < list.Count; i++)
                     {
+                        var element = list[i];
                         if (element != null)
                         {
                             CheckPatternParam(options, element);
                         }
                     }
+
                     break;
                 case Nodes.YieldExpression:
                     break;
                 default:
                     //assert(param.type == Nodes.ObjectPattern, 'Invalid type');
-                    foreach (var property in param.As<ObjectPattern>().Properties)
+                    var properties = param.As<ObjectPattern>().Properties;
+                    for (var i = 0; i < properties.Count; i++)
                     {
+                        var property = properties[i];
                         CheckPatternParam(options, property.Value);
                     }
+
                     break;
             }
         }
@@ -2973,15 +2986,16 @@ namespace Esprima
 
                 case TokenType.Punctuator:
                     var value = _lookahead.Value;
-                    if ((string)value == "{")
+                    var s = (string) value;
+                    if (s == "{")
                     {
                         statement = ParseBlock();
                     }
-                    else if ((string)value == "(")
+                    else if (s == "(")
                     {
                         statement = ParseExpressionStatement();
                     }
-                    else if ((string)value == ";")
+                    else if (s == ";")
                     {
                         statement = ParseEmptyStatement();
                     }

--- a/src/Esprima/JitHelper.cs
+++ b/src/Esprima/JitHelper.cs
@@ -11,5 +11,14 @@ namespace Esprima
             return default;
 #pragma warning restore 162
         }
+        
+        public static T Throw<T>() where T : Exception, new()
+        {
+            throw new T();
+#pragma warning disable 162 // unreachable code
+            return default;
+#pragma warning restore 162
+        }
+
     }
 }

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -556,13 +556,13 @@ namespace Esprima
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static char CharCodeAt(this string source, int index)
         {
-            if (index < 0 || index > source.Length - 1)
+            if ((uint) size < (uint) items.Length)
             {
-                // char.MinValue is used as the null value
-                return char.MinValue;
+                return source[index];
             }
 
-            return source[index];
+            // char.MinValue is used as the null value
+            return char.MinValue;
         }
     }
 }

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -556,7 +556,7 @@ namespace Esprima
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static char CharCodeAt(this string source, int index)
         {
-            if ((uint) size < (uint) items.Length)
+            if ((uint) index < (uint) source.Length)
             {
                 return source[index];
             }

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -318,7 +318,7 @@ namespace Esprima.Utils
             //Here we construct the function so if we iterate only functions we will be able to iterate ArrowFunctions too
             var statement =
                 arrowFunctionExpression.Expression
-                    ? new BlockStatement(new Ast.List<StatementListItem> {new ReturnStatement(arrowFunctionExpression.Body.As<Expression>())})
+                    ? new BlockStatement(new Ast.List<StatementListItem>(1) {new ReturnStatement(arrowFunctionExpression.Body.As<Expression>())})
                     : arrowFunctionExpression.Body.As<BlockStatement>();
             var func = new FunctionExpression(new Identifier(null),
                 arrowFunctionExpression.Params,


### PR DESCRIPTION
I went checked what could be done to further improve the new List performance and here are some tweaks. Feel free to reject, cherry-pick or use however you want. You can also double-check the numbers whether they make sense. There's not much improvement on file parsing though, underscore remains a mystery...

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17763
Intel Core i7-6820HQ CPU 2.70GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.2.101
  [Host]     : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT


```
|               Method |      Mean |     Error |    StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------------- |----------:|----------:|----------:|--------:|-------:|----------:|
|           AstListAdd | 23.820 us | 0.1754 us | 0.1641 us | 31.2195 |      - |  131368 B |
|           BclListAdd | 26.968 us | 0.1820 us | 0.1520 us | 31.2195 | 7.7820 |  131408 B |
|           AstListFor |  9.647 us | 0.0177 us | 0.0147 us |       - |      - |       0 B |
|           BclListFor | 11.790 us | 0.0060 us | 0.0047 us |       - |      - |       0 B |
|     AstListAddAndFor | 32.123 us | 0.1109 us | 0.0983 us | 31.1890 |      - |  131368 B |
|     BclListAddAndFor | 32.900 us | 0.1351 us | 0.1264 us | 31.1890 |      - |  131408 B |
| AstListAddAndForEach | 49.238 us | 0.1208 us | 0.1130 us | 31.1890 |      - |  131368 B |
| BclListAddAndForEach | 47.575 us | 0.2954 us | 0.2764 us | 31.1890 |      - |  131408 B |
|       AstListForEach | 25.194 us | 0.0198 us | 0.0176 us |       - |      - |       0 B |
|       BclListForEach | 22.326 us | 0.0120 us | 0.0100 us |       - |      - |       0 B |